### PR TITLE
Change commit digest display

### DIFF
--- a/main.go
+++ b/main.go
@@ -324,7 +324,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			{Title: "Create Time", Width: 19},
 			// No need to make this too long - it's not really
 			// useful to consumers.
-			{Title: "B5 Digest", Width: 9},
+			{Title: "b5 Digest", Width: 9},
 			// TODO: What else is useful here?
 		}
 		rows := make([]table.Row, len(msg))


### PR DESCRIPTION
Commits from the v1 API should always have b5 digests, so no need to include the prefix in the table - just rename the column.