### PR TITLE
go.mod: Bump staticcheck to v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	golang.org/x/tools v0.44.1-0.20260420230617-19499e7caabc // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260223185530-2f722ef697dc // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260223185530-2f722ef697dc // indirect
-	honnef.co/go/tools v0.8.0-rc.1 // indirect
+	honnef.co/go/tools v0.8.0 // indirect
 )
 
 tool honnef.co/go/tools/cmd/staticcheck

--- a/go.sum
+++ b/go.sum
@@ -155,3 +155,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.8.0-rc.1 h1:wqMm2kjcEXMOr+6yau+pdKqJKe6l2N1aKPkpini+Kzk=
 honnef.co/go/tools v0.8.0-rc.1/go.mod h1:XA+OnlRA9EDh/ukGvXMNSZNKGwFQJ+5dER0ioUkOxks=
+honnef.co/go/tools v0.8.0 h1:UacpzPr7D6i5BAjTkA7sNVcx4kIbhAZcQ4zYtKiXx68=
+honnef.co/go/tools v0.8.0/go.mod h1:XA+OnlRA9EDh/ukGvXMNSZNKGwFQJ+5dER0ioUkOxks=


### PR DESCRIPTION
staticcheck v0.8.0 (release [2026.2](https://github.com/dominikh/go-tools/releases/tag/2026.2)) shipped on 2026-08-20 with Go 1.27 support, so the release-candidate pin can go.

This repo was pinned to `v0.8.0-rc.1` because v0.7.0 could not analyse Go 1.27 source — it either panicked on new syntax or failed to decode the 1.27 standard library's export data ([#1711](https://github.com/dominikh/go-tools/issues/1711), [#1732](https://github.com/dominikh/go-tools/issues/1732)). The RC was the maintainer's recommended stopgap; this restores a stable version.

`just lint` and `go test ./...` pass locally.